### PR TITLE
Revert "Changed launch file to use kinect2_bridge's launch file instead of node"

### DIFF
--- a/root/usr/sbin/kinect2-config
+++ b/root/usr/sbin/kinect2-config
@@ -7,9 +7,9 @@ then
     echo "groovy exists..."
     sudo sed -i 's:</launch>:\
     <machine name="pr2-head" address="pr2-head" user="pr2-head" password="clearpath" env-loader="/home/pr2-head/kinect_ws/devel/env.sh"/>\
-    <include file="$(find kinect2_bridge)/launch/kinect2_bridge.launch">\
-    \t<arg name="base_name_tf" value="head_mount_kinect2"/>\
-    </include>\
+    <node machine="pr2-head" pkg="kinect2_bridge" type="kinect2_bridge" name="kinect2_bridge">\
+    \t<param name="base_name_tf" value="head_mount_kinect2"/>\
+    </node>\
     </launch>:i' /etc/ros/groovy/robot.launch
 fi
 
@@ -18,9 +18,9 @@ then
     echo "hydro exists..."
     sudo sed -i 's:</launch>:\
     <machine name="pr2-head" address="pr2-head" user="pr2-head" password="clearpath" env-loader="/home/pr2-head/kinect_ws/devel/env.sh"/>\
-    <include file="$(find kinect2_bridge)/launch/kinect2_bridge.launch">\
-    \t<arg name="base_name_tf" value="head_mount_kinect2"/>\
-    </include>\
+    <node machine="pr2-head" pkg="kinect2_bridge" type="kinect2_bridge" name="kinect2_bridge">\
+    \t<param name="base_name_tf" value="head_mount_kinect2"/>\
+    </node>\
     </launch>:i' /etc/ros/hydro/robot.launch
 fi
 
@@ -29,9 +29,9 @@ then
     echo "indigo exists..."
     sudo sed -i 's:</launch>:\
     <machine name="pr2-head" address="pr2-head" user="pr2-head" password="clearpath" env-loader="/home/pr2-head/kinect_ws/devel/env.sh"/>\
-    <include file="$(find kinect2_bridge)/launch/kinect2_bridge.launch">\
-    \t<arg name="base_name_tf" value="head_mount_kinect2"/>\
-    </include>\
+    <node machine="pr2-head" pkg="kinect2_bridge" type="kinect2_bridge" name="kinect2_bridge">\
+    \t<param name="base_name_tf" value="head_mount_kinect2"/>\
+    </node>\
     </launch>:i' /etc/ros/indigo/robot.launch
 fi
 

--- a/root/usr/sbin/kinect2-rm
+++ b/root/usr/sbin/kinect2-rm
@@ -6,27 +6,28 @@ if [ -d "/etc/ros/groovy" ];
 then
     echo "groovy exists..."
     sudo sed -i 's#<machine name="pr2-head" address="pr2-head" user="pr2-head" password="clearpath" env-loader="/home/pr2-head/kinect_ws/devel/env.sh"/>##i' /etc/ros/groovy/robot.launch
-    sudo sed -i 's#<include file="$(find kinect2_bridge)/launch/kinect2_bridge.launch">##i' /etc/ros/groovy/robot.launch
-    sudo sed -i 's#<arg name="base_name_tf" value="head_mount_kinect2"/>##i' /etc/ros/groovy/robot.launch
-    sudo sed -i 's#</include>##i' /etc/ros/groovy/robot.launch
+    sudo sed -i 's#<node machine="pr2-head" pkg="kinect2_bridge" type="kinect2_bridge" name="kinect2_bridge">##i' /etc/ros/groovy/robot.launch
+    sudo sed -i 's#<param name="base_name_tf" value="head_mount_kinect2"/>##i' /etc/ros/groovy/robot.launch
+    sudo sed -i 's#</node>##i' /etc/ros/groovy/robot.launch
 fi
 
 if [ -d "/etc/ros/hydro" ];
 then
     echo "hydro exists..."
     sudo sed -i 's#<machine name="pr2-head" address="pr2-head" user="pr2-head" password="clearpath" env-loader="/home/pr2-head/kinect_ws/devel/env.sh"/>##i' /etc/ros/hydro/robot.launch
-    sudo sed -i 's#<include file="$(find kinect2_bridge)/launch/kinect2_bridge.launch">##i' /etc/ros/hydro/robot.launch
-    sudo sed -i 's#<arg name="base_name_tf" value="head_mount_kinect2"/>##i' /etc/ros/hydro/robot.launch
-    sudo sed -i 's#</include>##i' /etc/ros/hydro/robot.launch
+    sudo sed -i 's#<node machine="pr2-head" pkg="kinect2_bridge" type="kinect2_bridge" name="kinect2_bridge">##i' /etc/ros/hydro/robot.launch
+    sudo sed -i 's#<param name="base_name_tf" value="head_mount_kinect2"/>##i' /etc/ros/hydro/robot.launch
+    sudo sed -i 's#</node>##i' /etc/ros/hydro/robot.launch
 fi
 
 if [ -d "/etc/ros/indigo" ];
 then
     echo "indigo exists..."
     sudo sed -i 's#<machine name="pr2-head" address="pr2-head" user="pr2-head" password="clearpath" env-loader="/home/pr2-head/kinect_ws/devel/env.sh"/>##i' /etc/ros/indigo/robot.launch
-    sudo sed -i 's#<include file="$(find kinect2_bridge)/launch/kinect2_bridge.launch">##i' /etc/ros/indigo/robot.launch
-    sudo sed -i 's#<arg name="base_name_tf" value="head_mount_kinect2"/>##i' /etc/ros/indigo/robot.launch
-    sudo sed -i 's#</include>##i' /etc/ros/indigo/robot.launch
+    sudo sed -i 's#<node machine="pr2-head" pkg="kinect2_bridge" type="kinect2_bridge" name="kinect2_bridge">##i' /etc/ros/indigo/robot.launch
+    sudo sed -i 's#<param name="publish_tf" value="true"/>##i' /etc/ros/indigo/robot.launch
+    sudo sed -i 's#<param name="base_name_tf" value="head_mount_kinect2"/>##i' /etc/ros/indigo/robot.launch
+    sudo sed -i 's#</node>##i' /etc/ros/indigo/robot.launch
 fi
 
 echo 'kinect2_bridge removed from upstart'


### PR DESCRIPTION
Reverts pr2-debs/pr2-kinect2-config#23

Syntactically correct but roslaunch does not support remote launching. Will create a new launch file on c1's side that will support nodelets.